### PR TITLE
use OVERLAPS instead of INCOHERENT

### DIFF
--- a/src/Language/Haskell/DoNotation.hs
+++ b/src/Language/Haskell/DoNotation.hs
@@ -45,7 +45,7 @@ class PureSyntax (x :: Type -> Type) where
   return = pure
 
 
-instance {-# INCOHERENT #-}
+instance {-# OVERLAPS #-}
       Applicative m => PureSyntax m where
   pure = P.pure
 
@@ -69,7 +69,7 @@ class BindSyntax (x :: Type -> Type)
 instance  (P.Monad m, x ~ m) => BindSyntax m x m where
   (>>=) = (P.>>=)
 
-instance {-# INCOHERENT #-}
+instance {-# OVERLAPS #-}
       ( IxMonad m
       , x ~ m i j
       , y ~ m j k


### PR DESCRIPTION
Since `m i j` is more specific than `m`, OVERLAPS should be sufficient. The tests still pass, at least!